### PR TITLE
Cloudfront has free tier

### DIFF
--- a/docs/guides/cloudflare.md
+++ b/docs/guides/cloudflare.md
@@ -6,7 +6,7 @@
 
 While Ymir already comes with CloudFront as a content delivery network, you're not required to use it if you don't want to. You can disable CloudFront using the [`cdn`][1] project configuration option. But you can also use another content delivery network like [Cloudflare][2].
 
-Cloudflare is a popular content delivery network option because of its generous free tier. (CloudFront has no free tier.) It also has advanced features such as [Cloudflare workers][3], which CloudFront doesn't have.
+Cloudflare is a popular content delivery network option because of its generous free tier. It also has advanced features such as [Cloudflare workers][3], which CloudFront doesn't have.
 
 ## Prerequisites
 


### PR DESCRIPTION
The statement "CloudFront has no free tier" is no longer true (since NOV 2021)
https://aws.amazon.com/blogs/aws/aws-free-tier-data-transfer-expansion-100-gb-from-regions-and-1-tb-from-amazon-cloudfront-per-month/